### PR TITLE
Added mediator request UID

### DIFF
--- a/lib/user/user-session-spec.js
+++ b/lib/user/user-session-spec.js
@@ -7,11 +7,10 @@ var assert = require('assert');
 
 var sessionManager;
 
-describe("Mbaas Service Proxy", function() {
+describe("User Sessions", function() {
   var verifySessionStub;
 
   beforeEach(function() {
-
     verifySessionStub = mockMbaasServiceProxy.getMockVerifySessionStub();
     sessionManager = proxyquire('./user-session', {
       './mbaas-service-proxy': mockMbaasServiceProxy.getMockSessionObject(verifySessionStub)
@@ -20,23 +19,25 @@ describe("Mbaas Service Proxy", function() {
   });
 
   it("Testing valid session token", function(done) {
-
-    mediator.request('wfm:user:session:validate', 'myvalidsessiontoken', function(err, validationResponse) {
+    mediator.request('wfm:user:session:validate', 'myvalidsessiontoken').then(function(validationResponse) {
       sinon.assert.calledOnce(verifySessionStub);
-      assert.ok(!err, 'Error on myvalidsessiontoken' + err);
       assert(validationResponse.isValid === true);
+      done();
+    }).catch(function(err) {
+      assert.ok(!err, 'Error on myvalidsessiontoken' + err);
       done();
     });
   });
 
   it("Testing invalid session token", function(done) {
-
-    sessionManager(mediator, express(), 'service-name-guid2');
-    mediator.request('wfm:user:session:validate', 'myinvalidsessiontoken', function(err, validationResponse) {
+    mediator.request('wfm:user:session:validate', 'myinvalidsessiontoken').then(function(validationResponse) {
       sinon.assert.calledOnce(verifySessionStub);
-      assert.ok(!err, 'Error on myinvalidvalidsessiontoken' + err);
-      assert(validationResponse.isValid === true);
+      assert(validationResponse.isValid === false);
       done();
-    });
+    })
+      .catch(function(err) {
+        assert.ok(!err, 'Error on myinvalidvalidsessiontoken' + err);
+        done();
+      });
   });
 });

--- a/lib/user/user-session.js
+++ b/lib/user/user-session.js
@@ -54,13 +54,14 @@ module.exports = function(mediator, app, guid) {
 
   // subscribe for session validation topic
   self.mediator.subscribe('wfm:user:session:validate', function(sessionToken) {
+
     return msProxy.verifysession(sessionToken)
       .then(function(validationResponse) {
-        // needs to publish the validation response for the consumer
-        self.mediator.publish('done:' + 'wfm:user:session:validate', validationResponse);
+        // needs to publish the validation response topic
+        self.mediator.publish('done:' + 'wfm:user:session:validate:' + sessionToken, validationResponse);
       })
       .catch(function(err) {
-        self.mediator.publish('error:' + 'wfm:user:session:validate', err);
+        self.mediator.publish('error:' + 'wfm:user:session:validate' + sessionToken, err);
       });
   });
 };


### PR DESCRIPTION
# Changes

The mediator.request API requires a unique identifier to be specified for the `done` and `error` states.

It also returns a promise instead of a callback.